### PR TITLE
Replaced 'lang="en"' with 'lang="fr"' to avoid autotranslation

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/base_without_menu.html.twig
+++ b/templates/base_without_menu.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Since most of the browsers uses the lang attribute in the html tag to check the page language, you need to put it to the initials of your country.